### PR TITLE
fix build under Fedora 38

### DIFF
--- a/test/tempfile.h
+++ b/test/tempfile.h
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstdint>
 #include <vector>
 
 class tempfile {


### PR DESCRIPTION
Building brlaser under Fedora 38 gives the following error in test/tempfile.h:
error: 'uint8_t' was not declared in this scope

This commit fixes it by explicitly including `cstdin` in the file, so `uint8_t` is correctly defined there.